### PR TITLE
Typo fix Changes.tex

### DIFF
--- a/Changes.tex
+++ b/Changes.tex
@@ -30,9 +30,9 @@
 \end{Developers}
 
  % ===================================================================== -->
- \begin{Release}{2.58}{}
+ \begin{Release}{2.58}{February 9, 2015}
   \begin{Update}{gene}
-    Library \File{tex_def.rsc} extended with the primitives \verb|\i| and
+    Library \File{tex\_def.rsc} extended with the primitives \verb|\i| and
     \verb|\j|.
   \end{Update}
   \begin{Update}{gene}


### PR DESCRIPTION
Hello Gerd,
I have just deposit to Alioth the debian package for the latest upstream version of BibTool.
I found a litttle but annoying typo in `Changes.tex'. I also took the opportunity to add the date.
Best wishes,
Jerome