### PR TITLE
LaTeX doc style: backward compatibility: old font cmd

### DIFF
--- a/doc/bibtool-doc.sty
+++ b/doc/bibtool-doc.sty
@@ -17,7 +17,13 @@
 		linkcolor=blue,
 		urlcolor=blue,
 		filecolor=blue,
-                citecolor=blue]{hyperref}
+		citecolor=blue]{hyperref}
+
+\renewcommand{\rm}{\rmfamily}
+\renewcommand{\sf}{\sffamily}
+\renewcommand{\tt}{\ttfamily}
+\renewcommand{\bf}{\bfseries}
+\renewcommand{\sc}{\scshape}
 
 \DeclareRobustCommand\BibTool{\textsc{Bib\hskip-.1em\-%
         \mbox{T\hskip-.15emo\hskip-.05emo\hskip-.05eml}}}


### PR DESCRIPTION
This patch fixes the FTBFS Debian bug [825894](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=825894)caused by `old font cmd'.
It appears that the very same issue exists for doc/c_lib.tex but my understanding is that this part of the project is currently being improved while its output is not currently distributed within Debian (technically its composition has been neutralized but not corrected).