### PR TITLE
bibtool library: renaming: bib -> bibtool

### DIFF
--- a/AutoConf/makefile.in
+++ b/AutoConf/makefile.in
@@ -527,7 +527,7 @@ test check: Test
 Test:
 	(cd test; $(MAKE))
 
-libbib.a: $(OLIBFILES)
+libbibtool.a: $(OLIBFILES)
 	$(AR) $@ $(OLIBFILES) regex.o
 	$(RANLIB) $@
 

--- a/Changes.tex
+++ b/Changes.tex
@@ -50,6 +50,14 @@
 \begin{multicols}2\RaggedRight
 
  % =====================================================================
+ \begin{Release}{2.66}{????? ??, 2016}
+  \begin{Update}{gene}
+    Rename \File{libbib.a} to \File{libbibtool.a} for consistency and to
+		avoid any name collision.
+  \end{Update}
+ \end{Release}
+
+ % =====================================================================
  \begin{Release}{2.65}{June 14, 2016}
   \begin{Fix}{gene}
     Hash function and value storing for field name mapping during xref

--- a/doc/c_lib.tex
+++ b/doc/c_lib.tex
@@ -226,15 +226,15 @@ For UNIX this is prepared in the makefile. Usually an invocation of
 make should be enough:
 
 \begin{verbatim}
-  make libbib.a
+  make libbibtool.a
 \end{verbatim}
 
 This invocation of make is in fact the same as the following two
 commands:
 
 \begin{verbatim}
-  ar r libbib.a $OFILES
-  ranlib libbib.a
+  ar r libbibtool.a $OFILES
+  ranlib libbibtool.a
 \end{verbatim}
 
 Here |$OFILES| denotes the list of object files as described above. On
@@ -261,10 +261,10 @@ you have created the object file |mybib.o| for it. The linking step
 can be performed with the following command:
 
 \begin{verbatim}
-  cc mybib.o -L$DIR -lbib -o mybib
+  cc mybib.o -L$DIR -lbibtool -o mybib
 \end{verbatim}
 
-Here |$DIR| denotes the path containing the file |libbib.a|. This path
+Here |$DIR| denotes the path containing the file |libbibtool.a|. This path
 can be omitted if the library has been installed in a ``standard''
 place like |/usr/lib|.
 

--- a/makefile.ami
+++ b/makefile.ami
@@ -504,7 +504,7 @@ clean:
 veryclean: clean
 	-$(RM) bibtool
 
-libbib.a: $(OLIBFILES)
+libbibtool.a: $(OLIBFILES)
 	$(AR) $@ $(OLIBFILES) regex.o
 	$(RANLIB) $@
 

--- a/makefile.ata
+++ b/makefile.ata
@@ -496,7 +496,7 @@ clean:
 veryclean: clean
 	-$(RM) bibtool
 
-libbib.a: $(OLIBFILES)
+libbibtool.a: $(OLIBFILES)
 	$(AR) $@ $(OLIBFILES) regex.o
 	$(RANLIB) $@
 

--- a/makefile.dos
+++ b/makefile.dos
@@ -550,7 +550,7 @@ veryclean: clean
 .c.o:
 	$(CC) $(C_FLAGS) -c $<
 
-libbib.a: $(OLIBFILES)
+libbibtool.a: $(OLIBFILES)
 	$(AR) $@ $(OLIBFILES) regex.o
 	$(RANLIB) $@
 

--- a/makefile.unx
+++ b/makefile.unx
@@ -527,7 +527,7 @@ test check: Test
 Test:
 	(cd test; $(MAKE))
 
-libbib.a: $(OLIBFILES)
+libbibtool.a: $(OLIBFILES)
 	$(AR) $@ $(OLIBFILES) regex.o
 	$(RANLIB) $@
 


### PR DESCRIPTION
The idea is to avoid any collision with other software library. It is also consistent with the  ld-version-script naming scheme.
