### PR TITLE
explicit local load in the perl test module

### DIFF
--- a/test/lib/BUnit.pm
+++ b/test/lib/BUnit.pm
@@ -277,7 +277,7 @@ sub suites {
     $suite   = $_;
     $suite   =~ s/\.t$//;
 
-    my $ret = do "$_";
+    my $ret = do "./$_";
     unless($ret) {
       if ($@) {                   warn "couldn't parse $_: $@\n"
       } elsif(not defined $ret) { warn "couldn't do $_: $!\n"


### PR DESCRIPTION
Implement explicit local load in test perl module as
'.' should be removed from @INC (CVE-2016-1238).