### PR TITLE
silence gcc (pointer-to-int-cast)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,7 @@ dnl Check for headers.
 AC_CHECK_HEADERS(string.h)
 AC_CHECK_HEADERS(stdlib.h)
 AC_CHECK_HEADERS(stdbool.h)
+AC_CHECK_HEADERS(stdint.h)
 AC_CHECK_HEADERS(time.h)
 AC_CHECK_FUNCS(getenv)
 AC_CHECK_FUNCS(strrchr)

--- a/include/bibtool/general.h
+++ b/include/bibtool/general.h
@@ -71,12 +71,18 @@
 #endif
 
 
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#else
+typedef intptr_t int;
+#endif
+
 #ifdef HAVE_STDBOOL_H
 #include <stdbool.h>
 #else
 typedef int bool;
 #define true  (1)
-#define false (0) 
+#define false (0)
 #endif
 
 /*-----------------------------------------------------------------------------

--- a/rewrite.c
+++ b/rewrite.c
@@ -806,7 +806,7 @@ void keep_field(spec)				   /*			     */
   Symbol* np;				   	   /*                        */
   Symbol field 	 = NO_SYMBOL;			   /*                        */
   Symbol pattern = NO_SYMBOL;		   	   /*                        */
-  int i;					   /*                        */
+  intptr_t i;					   /*                        */
  						   /*                        */
   sp_open(s);				   	   /*			     */
   if ((names = sp_symbols(&s)) == NULL)    	   /*		             */
@@ -846,7 +846,7 @@ void keep_field(spec)				   /*			     */
 			 field,			   /*                        */
 			 RULE_KEEP | RULE_REGEXP,  /*                        */
 			 true);	   	   	   /*                        */
-    i = (int)(*np) % K_RULES_SIZE;		   /*                        */
+    i = (intptr_t)(*np) % K_RULES_SIZE;		   /*                        */
     if (i < 0) i = -i;				   /*                        */
  						   /*                        */
     NextRule(rule) = k_rules[i];		   /*                        */
@@ -897,7 +897,7 @@ static bool dont_keep(sym,rec,db)		   /*                        */
   Record rec;					   /*                        */
   DB     db;					   /*                        */
 { Rule   r;					   /*                        */
-  int    idx = (int)(sym) % K_RULES_SIZE;	   /*                        */
+  intptr_t idx = (intptr_t)(sym) % K_RULES_SIZE;	   /*                        */
   if (idx < 0) idx = -idx;			   /*                        */
  						   /*                        */
   for (r = k_rules[idx]; r; r = NextRule(r))	   /*                        */


### PR DESCRIPTION
Fix the `pointer-to-int-cast' warning emitted by gcc (6.3.0) when the package builds