### PR TITLE
Fix typo on man page

### DIFF
--- a/doc/bibtool.1
+++ b/doc/bibtool.1
@@ -83,7 +83,7 @@ Enable sorting of entries.
 Enable sorting of entries in reverse order.
 .TP
 .BI \fB\-A\  type
-Determine key disambuguation;
+Determine key disambiguation;
 .IR type
 in 0, a, A.
 .SS "Selecting items"


### PR DESCRIPTION
I came across a small typo on the man page and thought I’d send you a quick patch in case you’d like to fix it.

Thanks for your work on BibTool, it’s a super useful part of my workflow!