### PR TITLE
[ci] Update actions/checkout to latest version 6

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: configure
       run: ./configure
     - name: make


### PR DESCRIPTION
Without updating at some point the used node.js version drops out of support.